### PR TITLE
Support for connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea

--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ function isExcludedByDirective(context, ast) {
     return isExcluded;
 }
 
-function getFieldSet(context, asts = context.fieldASTs || context.fieldNodes) {
+function getFieldSet(
+      context,
+      asts = context.fieldASTs || context.fieldNodes,
+      exclude = ['cursor']
+) {
     // for recursion: fragments doesn't have many sets
     if (!Array.isArray(asts)) {
         asts = [asts];
@@ -39,8 +43,17 @@ function getFieldSet(context, asts = context.fieldASTs || context.fieldNodes) {
         if (isExcludedByDirective(context, ast)) {
             return set;
         }
+
         switch (ast.kind) {
             case 'Field':
+                if (ast.selectionSet) {
+                    return Object.assign({}, set, getFieldSet(context, ast));
+                }
+
+                if (exclude.includes(ast.name.value)) {
+                    return set;
+                }
+
                 set[ast.name.value] = true;
                 return set;
             case 'InlineFragment':

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "devDependencies": {
     "coveralls": "^2.11.14",
     "graphql": "^0.8.1",
-    "jest": "^16.0.1"
+    "jest": "^16.0.1",
+    "graphql-relay": "^0.5.2"
   },
   "files": []
 }


### PR DESCRIPTION
Hey @jakepusateri - great library, and wanted to put out this PR just in case you find it useful. This feels pretty similar to your current PR for supporting nested fields, but the use case is specifically for [connections](https://facebook.github.io/relay/docs/graphql-connections.html).

As far as I know, GraphQL right now does not provide great support if you want to optimize your DB queries to only select specific fields after selecting multiple items. For instance, in a TODO example, if your query was something like:

```
SELECT description, date
FROM todos
WHERE date > 2017-01-01
AND date < 2017-02-01
```

Based on the current [Relay Modern example in Facebook's repo](https://github.com/relayjs/relay-examples/blob/master/todo-modern/data/schema.js) the expectation is to use connections for pagination / lists of things.

Totally understand if this feels overly specific / is not consistent with what you're trying to build. Admittedly, this really is to support using Relay on the client.