### PR TITLE
handle undefined directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function getBooleanArgumentValue(info, ast) {
 }
 
 function isExcludedByDirective(info, ast) {
-    const directives = ast.directives;
+    const directives = ast.directives || [];
     let isExcluded = false;
     directives.forEach((directive) => {
         switch (directive.name.value) {


### PR DESCRIPTION
@jakepusateri I ran into a case where `directives` was undefined. When using [apollo-link-schema](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-schema) a [fieldNode without directives](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-utilities/src/transform.ts#L22-L28) get's added to the AST. 

This makes sure there is at least an empty array to call `forEach` on. I didn't see a straight forward way to add a test. LMK if you have any pointers . 
