### PR TITLE
Named inline fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,18 @@ resolve(parent, args, context, info) {
     return fetch('/someservice/?fields=' + fields.join(','));
 }
 ```
+
+### named inline fragments
+When supplying `true` as the second argument (`getFieldList(ast, true)`), the type of a spread is included in the path:
+```
+{
+  someType {
+    e {
+      ... on NestedType {
+        x
+      }
+    }
+  }
+}
+```
+results in: `[e.NestedType.x]` instead of `[e.x]`

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -2,11 +2,11 @@ const { graphql, GraphQLSchema, GraphQLString, GraphQLObjectType, buildSchema } 
 const getFieldList = require('../');
 const { Parser, Printer } = require('graphql/language');
 
-function testGetFields(query, expected, variables) {
+function testGetFields(query, expected, variables, namedInlineFragments = false) {
     return Promise.resolve().then(() => {
         let actual;
         function resolver(parent, args, context, info) {
-            actual = getFieldList(info);
+            actual = getFieldList(info, namedInlineFragments);
             return { a: 1, b: 2, c: 3, d: 4, e: { a: 5 } };
         }
         const resolverSpy = jest.fn(resolver);
@@ -302,6 +302,27 @@ it('works with nested types and inline fragments', () => {
     }
     `,
         ['a', 'b', 'e.x']
+    );
+});
+
+it('namedInlineFragments works with nested types and inline fragments', () => {
+    return testGetFields(
+        `
+    {
+        someType {
+            a
+            b
+            e {
+                ... on NestedType {
+                    x
+                }
+            }
+        }
+    }
+    `,
+        ['a', 'b', 'e.NestedType.x'],
+        undefined,
+        true
     );
 });
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function dotConcat(a, b) {
     return a ? `${a}.${b}` : b;
 }
 
-function getFieldSet(info, asts = info.fieldASTs || info.fieldNodes, prefix = '') {
+function getFieldSet(info, asts = info.fieldASTs || info.fieldNodes, prefix = '', namedInlineFragments = false) {
     // for recursion: fragments doesn't have many sets
     if (!Array.isArray(asts)) {
         asts = [asts];
@@ -49,19 +49,22 @@ function getFieldSet(info, asts = info.fieldASTs || info.fieldNodes, prefix = ''
             case 'Field':
                 const newPrefix = dotConcat(prefix, ast.name.value);
                 if (ast.selectionSet) {
-                    return Object.assign({}, set, getFieldSet(info, ast, newPrefix));
+                    return Object.assign({}, set, getFieldSet(info, ast, newPrefix, namedInlineFragments));
                 } else {
                     set[newPrefix] = true;
                     return set;
                 }
             case 'InlineFragment':
-                return Object.assign({}, set, getFieldSet(info, ast, prefix));
+                const nextPrefix = namedInlineFragments
+                  ? dotConcat(prefix, ast.typeCondition.name.value)
+                  : prefix
+                return Object.assign({}, set, getFieldSet(info, ast, nextPrefix, namedInlineFragments));
             case 'FragmentSpread':
-                return Object.assign({}, set, getFieldSet(info, info.fragments[ast.name.value], prefix));
+                return Object.assign({}, set, getFieldSet(info, info.fragments[ast.name.value], prefix, namedInlineFragments));
         }
     }, {});
 }
 
-module.exports = function getFieldList(info) {
-    return Object.keys(getFieldSet(info));
+module.exports = function getFieldList(info, namedInlineFragments) {
+    return Object.keys(getFieldSet(info, undefined, undefined, namedInlineFragments));
 };


### PR DESCRIPTION
Hi. I needed a way to know the type of a requested field.

- minor change, the default behavior stays the same
- when supplying `true` as the second argument (`getFieldList(ast, true)`), the type of a spread is included in the path:
```
{
        someType {
            e {
                ... on NestedType {
                    x
                }
            }
        }
    }
```
results in: `[e.NestedType.x]` instead of `[e.x]`


Background: Internally Document and Comment have a content field. To optimize the query to the DB I need to know which type needs content. The (shorted) query we do is as follows:
```
query getSearchResults {
  search {
    nodes {
      __typename
      entity {
        __typename
        ... on Comment {
          __typename
          content
          createdAt
        }
        ... on Document {
          __typename
            path
            title
          }
        }
        ... on User {
          id
          usernamme
        }
      }
    }
  }
}
```